### PR TITLE
Fix various compilation issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 obj-m += piProx.o
+UNAME := $(shell uname -r)
 
 all: modules printhex
  
 modules: piProx.c
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules 
+	$(MAKE) -C /lib/modules/$(UNAME)/build M=$(CURDIR) modules 
 clean:
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean
+	$(MAKE) -C /lib/modules/$(UNAME)/build M=$(CURDIR) clean
 	$(RM) printhex
 
 printhex: libpiprox.c printhex.c

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ obj-m += piProx.o
 all: modules printhex
  
 modules: piProx.c
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules 
+	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules 
 clean:
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean
 	$(RM) printhex
 
 printhex: libpiprox.c printhex.c

--- a/piProx.c
+++ b/piProx.c
@@ -23,7 +23,7 @@
 #include <linux/timer.h>
 #include <linux/string.h>
 #include <linux/fs.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 #include <linux/device.h>
 #include <linux/wait.h>
 


### PR DESCRIPTION
`asm/uaccess.h` appears to have been moved to `linux/uaccess.h` in recent Raspbian kernels. Also fixes a bug in the makefile preventing the piProx.ko from being compiled.